### PR TITLE
Add a property to turn off setting charset for the compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ To configure this plugin you can declare a block as follows:
         minify = false //default value
         //Vaadin sass compiler is pretty verbose about errors
         silenceErrors = false //default value
+        // Ability to turn off charset setting (helpful for JavaFX css generation)
+        setCharSet = true // default value 
         
         /*
         //You can add scan directories to look for SCSS files in the JARs

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 }
 
 group 'it.tellnet'
-version '1.2'
+version '1.3'
 
 apply plugin: 'groovy'
 apply plugin: 'maven-publish'
@@ -42,7 +42,7 @@ pluginBundle {
 
   plugins {
     greetingsPlugin {
-      id = 'it.tellnet.sass'
+      id = 'it.tellnet.gradle-sass'
       displayName = 'Gradle Sass Plugin'
     }
   }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Dec 17 11:07:04 CET 2015
+#Fri Feb 12 00:13:49 EST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.9-all.zip

--- a/src/main/groovy/it/tellnet/gradle/SassCompileTask.groovy
+++ b/src/main/groovy/it/tellnet/gradle/SassCompileTask.groovy
@@ -27,6 +27,7 @@ class SassCompileTask extends DefaultTask {
             scss.outDir = f
             scss.minify = ext.minify
             scss.silent = ext.silenceErrors
+            scss.setCharSet = ext.setCharSet
             scss.exec()
         }
     }

--- a/src/main/groovy/it/tellnet/gradle/SassCompilerImpl.groovy
+++ b/src/main/groovy/it/tellnet/gradle/SassCompilerImpl.groovy
@@ -3,9 +3,6 @@ package it.tellnet.gradle
 import com.vaadin.sass.internal.ScssStylesheet
 import com.vaadin.sass.internal.handler.SCSSDocumentHandlerImpl
 import com.vaadin.sass.internal.handler.SCSSErrorHandler
-import org.gradle.api.Project
-import org.w3c.css.sac.ErrorHandler
-
 /**
  * @author Radu Andries
  */
@@ -15,6 +12,8 @@ class SassCompilerImpl {
     ProjectAwareResolver resolver
     Boolean minify = false
     Boolean silent = false
+    Boolean setCharSet = true
+
 
     def exec(){
         SCSSErrorHandler handler
@@ -24,7 +23,12 @@ class SassCompilerImpl {
             handler = new SCSSErrorHandler()
         ScssStylesheet sass = ScssStylesheet.get(scss.absolutePath, null, new SCSSDocumentHandlerImpl(),handler)
         sass.setFile(scss)
-        sass.setCharset('UTF-8')
+
+        // setting charset breaks JavaFX CSS generation
+        // and should be turned off for JavaFX applications
+        if ( setCharSet ) {
+            sass.setCharset('UTF-8')
+        }
         sass.addResolver(resolver.getFSResolver())
         sass.addResolver(resolver)
         def basename = scss.getName().replaceAll('\\.scss','.css')

--- a/src/main/groovy/it/tellnet/gradle/SassPluginExtension.groovy
+++ b/src/main/groovy/it/tellnet/gradle/SassPluginExtension.groovy
@@ -9,6 +9,7 @@ class SassPluginExtension {
     String cssDir = 'build/sass'
     boolean minify = false
     boolean silenceErrors = false
+    boolean setCharSet = true
 
     void searchDirectories(String... paths){
         if(paths!=null)


### PR DESCRIPTION
Having charset in SCSS breaks JavaFX css generation, so we are making it optional
